### PR TITLE
Fix extra leading space in YearPicker

### DIFF
--- a/HackerTube/Features/Browse/BrowseView.swift
+++ b/HackerTube/Features/Browse/BrowseView.swift
@@ -107,6 +107,7 @@ struct YearPicker: View {
             Label("Year", systemImage: "calendar")
         }
         .pickerStyle(.menu)
+        .labelStyle(.iconOnly)
         .fixedSize(horizontal: true, vertical: false)
     }
 }


### PR DESCRIPTION
## Problem

The year picker in the Popular talks view (used both in the tvOS inline view and the iOS toolbar) shows extra leading space before the year number. This was caused by the `Label("Year", systemImage: "calendar")` displaying both the calendar icon *and* the "Year" text. In `.pickerStyle(.menu)`, this results in the text appearing as unwanted padding before the selected year.

## Fix

Added `.labelStyle(.iconOnly)` to the `Picker`, which makes the label closure render only the calendar icon without the "Year" text. This removes the extra leading space while keeping the visual calendar indicator.

Fixes #40.