### PR TITLE
Make talk `updated_at` property optional

### DIFF
--- a/CCCApi/Sources/CCCApi/Models/Conference.swift
+++ b/CCCApi/Sources/CCCApi/Models/Conference.swift
@@ -16,7 +16,7 @@ public struct Conference: Decodable, Identifiable, Sendable {
     public let acronym: String
     public let slug: String
     public let title: String
-    public let updatedAt: Date
+    public let updatedAt: Date?
     public let eventLastReleasedAt: Date?
     public let events: [Talk]?
     public let link: URL?
@@ -31,7 +31,7 @@ public struct Conference: Decodable, Identifiable, Sendable {
     public var id: String { slug }
 
     init(
-        acronym: String, slug: String, title: String, updatedAt: Date,
+        acronym: String, slug: String, title: String, updatedAt: Date?,
         eventLastReleasedAt: Date? = nil, events: [Talk]? = nil, link: URL? = nil,
         description: String? = nil, aspectRatio: AspectRatio? = nil, webgenLocation: String,
         url: URL, logoURL: URL, imagesURL: URL? = nil, recordingsURL: URL? = nil
@@ -75,7 +75,7 @@ public struct Conference: Decodable, Identifiable, Sendable {
         acronym = try container.decode(String.self, forKey: .acronym)
         slug = try container.decode(String.self, forKey: .slug)
         title = try container.decode(String.self, forKey: .title)
-        updatedAt = try container.decode(Date.self, forKey: .updatedAt)
+        updatedAt = try container.decode(Date?.self, forKey: .updatedAt)
         eventLastReleasedAt = try container.decode(Date?.self, forKey: .eventLastReleasedAt)
         events = try? container.decode([Event].self, forKey: .events)
         link = try? container.decode(URL?.self, forKey: .link)

--- a/HackerTube/Features/Conferences/ConferencesView.swift
+++ b/HackerTube/Features/Conferences/ConferencesView.swift
@@ -50,13 +50,14 @@ struct ConferencesView: View {
     func refresh() async {
         do {
             conferences = try await api.conferences()
-                .filter { conference in
-                    conference.eventLastReleasedAt != nil
-                }
                 .sorted { lhs, rhs in
-                    let lhsVal = lhs.eventLastReleasedAt ?? lhs.updatedAt
-                    let rhsVal = rhs.eventLastReleasedAt ?? rhs.updatedAt
-                    return lhsVal > rhsVal
+                    // Sort by updated at, falling back to title sort.
+                    if let lhsUpdatedAt = lhs.eventLastReleasedAt ?? lhs.updatedAt,
+                       let rhsUpdatedAt = rhs.eventLastReleasedAt ?? rhs.updatedAt {
+                        return lhsUpdatedAt > rhsUpdatedAt
+                    } else {
+                        return lhs.title < rhs.title
+                    }
                 }
         } catch is CancellationError {
         } catch {


### PR DESCRIPTION
This is currently breaking the Conferences tab due to a JSON decoding error. For FOSSGIS 2014, updated_at = null.