### PR TITLE
Release 1.5.1

### DIFF
--- a/HackerTube.xcodeproj/project.pbxproj
+++ b/HackerTube.xcodeproj/project.pbxproj
@@ -387,7 +387,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = TopShelf/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = TopShelf;
@@ -409,7 +408,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = TopShelf/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = TopShelf;
@@ -432,7 +430,6 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = nl.bernson.CCCTubeTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -449,7 +446,6 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = nl.bernson.CCCTubeTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -463,6 +459,8 @@
 		};
 		D5A156E0289462B3006989FF /* Debug configuration for PBXProject "HackerTube" */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReferenceAnchor = D5AFD6D92C9BFCF700BF89F5 /* HackerTube */;
+			baseConfigurationReferenceRelativePath = Configuration/HackerTube.xcconfig;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
@@ -496,6 +494,7 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEVELOPMENT_TEAM = 3W68UU92K3;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
@@ -518,7 +517,6 @@
 				INFOPLIST_KEY_UIRequiredDeviceCapabilities = arm64;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 1.6.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -536,6 +534,8 @@
 		};
 		D5A156E1289462B3006989FF /* Release configuration for PBXProject "HackerTube" */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReferenceAnchor = D5AFD6D92C9BFCF700BF89F5 /* HackerTube */;
+			baseConfigurationReferenceRelativePath = Configuration/HackerTube.xcconfig;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
@@ -569,6 +569,7 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = 3W68UU92K3;
 				ENABLE_NS_ASSERTIONS = NO;
@@ -585,7 +586,6 @@
 				INFOPLIST_KEY_UIRequiredDeviceCapabilities = arm64;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 1.6.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SDKROOT = appletvos;
@@ -611,7 +611,6 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = HackerTube/HackerTube.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"HackerTube/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -653,7 +652,6 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = HackerTube/HackerTube.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"HackerTube/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -690,7 +688,6 @@
 			buildSettings = {
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -711,7 +708,6 @@
 			buildSettings = {
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/HackerTube/Configuration/HackerTube.xcconfig
+++ b/HackerTube/Configuration/HackerTube.xcconfig
@@ -1,0 +1,13 @@
+//
+//  HackerTube.xcconfig
+//  HackerTube
+//
+//  Created by Mathijs Bernson on 15/04/2026.
+//
+
+// Configuration settings file format documentation can be found at:
+// https://developer.apple.com/documentation/xcode/adding-a-build-configuration-file-to-your-project
+// Build settings reference:
+// https://developer.apple.com/documentation/xcode/build-settings-reference
+
+MARKETING_VERSION = 1.5.1


### PR DESCRIPTION
This release fixes a data decoding problem with the media.ccc.de API, which caused the "Conferences" tab to not load.

Other changes in this release:
- Fix playback speed setting not appearing on tvOS
- Tweak German translations