### PR TITLE
Improve video playback robustness and follow best practices

### DIFF
--- a/HackerTube/Features/Talk/TalkPlayerView.swift
+++ b/HackerTube/Features/Talk/TalkPlayerView.swift
@@ -34,6 +34,11 @@ struct TalkPlayerView: View {
             }
             .onDisappear {
                 viewModel.pause()
+                UIApplication.shared.isIdleTimerDisabled = false
+            }
+            .onChange(of: viewModel.isPlaying) { _, isPlaying in
+                // Keep the display awake while playback is in progress.
+                UIApplication.shared.isIdleTimerDisabled = isPlaying
             }
             #if os(iOS)
                 .overlay {

--- a/HackerTube/Features/Talk/TalkPlayerViewModel.swift
+++ b/HackerTube/Features/Talk/TalkPlayerViewModel.swift
@@ -11,47 +11,94 @@ import Foundation
 import os.log
 
 @Observable
+@MainActor
 class TalkPlayerViewModel {
     var player = AVPlayer()
 
     var currentRecording: Recording?
 
+    private(set) var isPlaying = false
+
+    @ObservationIgnored
     private let factory = TalkMetadataFactory()
-    private let logger = Logger(
-        subsystem: Bundle.main.bundleIdentifier!, category: "TalkPlayerViewModel")
+
+    @ObservationIgnored
+    private let logger = Logger(subsystem: Bundle.main.bundleIdentifier!, category: "TalkPlayerViewModel")
+
+    @ObservationIgnored
+    private var timeControlObserver: NSKeyValueObservation?
+
+    init() {
+        timeControlObserver = player.observe(\.timeControlStatus, options: [.initial, .new]) {
+            [weak self] player, _ in
+            let playing = player.timeControlStatus == .playing
+            Task { @MainActor [weak self] in
+                self?.isPlaying = playing
+            }
+        }
+    }
 
     func prepareForPlayback(recording: Recording, talk: Talk) async {
         player.defaultRate = UserDefaults.standard.float(forKey: UserDefaultsKey.playbackRate.rawValue)
 
+        var metadata = factory.createMetadataItems(for: recording, talk: talk)
+
+        // Fetch the poster artwork up front so the complete metadata set,
+        // including artwork, is attached in a single assignment before the
+        // item is enqueued for playback.
+        if let imageURL = talk.posterURL ?? talk.thumbURL,
+            let posterImageData = try? await factory.fetchImageData(forURL: imageURL),
+            let posterImageMetadata = factory.createArtworkMetadataItem(imageData: posterImageData)
+        {
+            metadata.append(posterImageMetadata)
+        }
+
         let playerItem = AVPlayerItem(url: recording.recordingURL)
-        playerItem.externalMetadata = factory.createMetadataItems(for: recording, talk: talk)
+        playerItem.externalMetadata = metadata
 
         player.replaceCurrentItem(with: playerItem)
         self.currentRecording = recording
         logger.info(
             "Preparing playback of recording: \(recording.recordingURL.absoluteString, privacy: .public)"
         )
-
-        if let imageURL = talk.posterURL ?? talk.thumbURL,
-            let posterImageData = try? await factory.fetchImageData(forURL: imageURL),
-            let posterImageMetadata = factory.createArtworkMetadataItem(imageData: posterImageData)
-        {
-            playerItem.externalMetadata.append(posterImageMetadata)
-        }
     }
 
     func preroll() async {
-        await withCheckedContinuation { continuation in
-            _ = player.observe(\.status, options: [.initial, .new]) { player, change in
-                if player.status == .readyToPlay {
-                    continuation.resume(returning: ())
-                }
-            }
+        // Wait for the player to become ready before prerolling.
+        let ready = await waitUntilReadyToPlay()
+        guard ready else {
+            logger.warning("Player failed to become ready for preroll")
+            return
         }
         if await player.preroll(atRate: 1.0) {
             logger.debug("Preroll success")
         } else {
             logger.warning("Preroll failed")
+        }
+    }
+
+    private func waitUntilReadyToPlay() async -> Bool {
+        var observation: NSKeyValueObservation?
+        defer { observation?.invalidate() }
+
+        return await withCheckedContinuation { continuation in
+            var didResume = false
+            let resume: (Bool) -> Void = { ready in
+                guard !didResume else { return }
+                didResume = true
+                continuation.resume(returning: ready)
+            }
+
+            observation = player.observe(\.status, options: [.initial, .new]) { player, _ in
+                switch player.status {
+                case .readyToPlay:
+                    resume(true)
+                case .failed:
+                    resume(false)
+                default:
+                    break
+                }
+            }
         }
     }
 

--- a/HackerTube/Features/VideoPlayer/VideoPlayerView.swift
+++ b/HackerTube/Features/VideoPlayer/VideoPlayerView.swift
@@ -12,8 +12,8 @@ import os.log
 struct VideoPlayerView: UIViewControllerRepresentable {
     let player: AVPlayer?
 
-    func makeUIViewController(context: Context) -> VideoPlayerViewController {
-        let playerViewController = VideoPlayerViewController()
+    func makeUIViewController(context: Context) -> AVPlayerViewController {
+        let playerViewController = AVPlayerViewController()
         playerViewController.delegate = context.coordinator
         playerViewController.modalPresentationStyle = .fullScreen
 
@@ -28,11 +28,13 @@ struct VideoPlayerView: UIViewControllerRepresentable {
         // The playback speeds don't appear on tvOS unless this is explicitly set.
         playerViewController.speeds = AVPlaybackSpeed.systemDefaultSpeeds
 
+        // Persist the user's chosen playback speed as they change it.
+        context.coordinator.observeSelectedSpeed(of: playerViewController)
+
         return playerViewController
     }
 
-    func updateUIViewController(_ playerViewController: VideoPlayerViewController, context: Context)
-    {
+    func updateUIViewController(_ playerViewController: AVPlayerViewController, context: Context) {
         playerViewController.player = player
     }
 
@@ -41,7 +43,7 @@ struct VideoPlayerView: UIViewControllerRepresentable {
     }
 
     static func dismantleUIViewController(
-        _ playerViewController: VideoPlayerViewController, coordinator: Coordinator
+        _ playerViewController: AVPlayerViewController, coordinator: VideoPlayerCoordinator
     ) {
         playerViewController.player?.cancelPendingPrerolls()
         playerViewController.player?.pause()
@@ -52,36 +54,21 @@ class VideoPlayerCoordinator: NSObject, AVPlayerViewControllerDelegate {
     let logger = Logger(
         subsystem: Bundle.main.bundleIdentifier!, category: "VideoPlayerCoordinator")
 
-    func playerViewController(
-        _ playerViewController: AVPlayerViewController,
-        failedToStartPictureInPictureWithError error: Error
-    ) {
-        logger.error("Failed to start picture in picture: \(error)")
-    }
-}
-
-class VideoPlayerViewController: AVPlayerViewController {
     private var selectedSpeedObserver: NSKeyValueObservation?
 
-    override func viewDidLoad() {
-        super.viewDidLoad()
-
-        selectedSpeedObserver = self.observe(\.selectedSpeed, options: [.new]) { controller, change in
+    func observeSelectedSpeed(of playerViewController: AVPlayerViewController) {
+        selectedSpeedObserver = playerViewController.observe(\.selectedSpeed, options: [.new]) {
+            _, change in
             if let selectedSpeed = change.newValue.flatMap({ $0 }) {
                 UserDefaults.standard.set(selectedSpeed.rate, forKey: UserDefaultsKey.playbackRate.rawValue)
             }
         }
     }
 
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-
-        UIApplication.shared.isIdleTimerDisabled = true
-    }
-
-    override func viewDidDisappear(_ animated: Bool) {
-        super.viewDidDisappear(animated)
-
-        UIApplication.shared.isIdleTimerDisabled = false
+    func playerViewController(
+        _ playerViewController: AVPlayerViewController,
+        failedToStartPictureInPictureWithError error: Error
+    ) {
+        logger.error("Failed to start picture in picture: \(error)")
     }
 }

--- a/HackerTube/HackerTubeApp.swift
+++ b/HackerTube/HackerTubeApp.swift
@@ -5,7 +5,6 @@
 //  Created by Mathijs Bernson on 29/07/2022.
 //
 
-import AVKit
 import SwiftUI
 import CCCApi
 
@@ -17,11 +16,6 @@ struct HackerTubeApp: App {
         WindowGroup {
             ContentView()
                 .environment(ApiService())
-                .onAppear {
-                    do {
-                        try AVAudioSession.sharedInstance().setCategory(.playback)
-                    } catch {}
-                }
         }
     }
 }

--- a/HackerTube/HackerTubeAppDelegate.swift
+++ b/HackerTube/HackerTubeAppDelegate.swift
@@ -5,11 +5,17 @@
 //  Created by Mathijs Bernson on 11/08/2025.
 //
 
+import AVFAudio
 import UIKit
+import os.log
 
 class HackerTubeAppDelegate: NSObject, UIApplicationDelegate {
+    private let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier!, category: "HackerTubeAppDelegate")
+
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
         registerDefaultSettings()
+        configureAudioSession()
         return true
     }
 
@@ -17,5 +23,13 @@ class HackerTubeAppDelegate: NSObject, UIApplicationDelegate {
         UserDefaults.standard.register(defaults: [
             UserDefaultsKey.playbackRate.rawValue : 1.0 as Float,
         ])
+    }
+
+    private func configureAudioSession() {
+        do {
+            try AVAudioSession.sharedInstance().setCategory(.playback)
+        } catch {
+            logger.error("Failed to configure audio session: \(error)")
+        }
     }
 }


### PR DESCRIPTION
- Fix potential preroll() hang by retaining the KVO status observation
- Stop subclassing AVPlayerViewController, move speed observation
- Drive the idle timer from actual playback state in the SwiftUI layer
- Assemble all external metadata, including poster artwork, before enqueuing the AVPlayerItem
- Move AVAudioSession configuration into the app delegate's launch